### PR TITLE
Support custom attributes in secondary_info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,18 @@ The battery level value is fetched from the entity `state`, from the attribute `
 or from a custom attribute defined with the `attribute` option. Numeric values (`0-100`) and some predefined
 string values (`high`, `normal`, `low`, etc..) are supported as a battery level value.
 
-| Name      | Type        | Default         | Description                                                                    |
-| --------- | ----------- | --------------- | ------------------------------------------------------------------------------ |
-| type      | string      | **Required**    | `custom:battery-entity-row`                                                    |
-| entity    | string      | **Required**    | `domain.my_entity_id`                                                          |
-| attribute | string      | `battery_level` | Override battery level attribute                                               |
-| name      | string      | `friendly_name` | Override entity `friendly_name`                                                |
-| unit      | string/bool | `%`             | Override default `unit`, or hide with `false`                                  |
-| icon      | string      |                 | Override dynamic battery `icon`                                                |
-| warning   | number      | `35`            | Level at which the icon will appear yellow                                     |
-| critical  | number      | `15`            | Level at which the icon will appear red                                        |
-| charging  | bool/object | `false`         | Indicate charging based on entity state. See charging object for more options. |
+| Name            | Type        | Default         | Description                                                                    |
+| --------------- | ----------- | --------------- | ------------------------------------------------------------------------------ |
+| type            | string      | **Required**    | `custom:battery-entity-row`                                                    |
+| entity          | string      | **Required**    | `domain.my_entity_id`                                                          |
+| attribute       | string      | `battery_level` | Override battery level attribute                                               |
+| name            | string      | `friendly_name` | Override entity `friendly_name`                                                |
+| secondary\_info | string      |                 | `last-changed`, `last-updated` or an attribute of the entity.                  |
+| unit            | string/bool | `%`             | Override default `unit`, or hide with `false`                                  |
+| icon            | string      |                 | Override dynamic battery `icon`                                                |
+| warning         | number      | `35`            | Level at which the icon will appear yellow                                     |
+| critical        | number      | `15`            | Level at which the icon will appear red                                        |
+| charging        | bool/object | `false`         | Indicate charging based on entity state. See charging object for more options. |
 
 Currently limited support for `secondary_info` option with value `last-changed`.
 

--- a/battery-entity-row.js
+++ b/battery-entity-row.js
@@ -84,10 +84,18 @@
         }
 
         renderSecondaryInfo() {
-            return this._config.secondary_info === 'last-changed' ?
-                html`<div class="secondary">
-                    <ha-relative-time datetime="${this.stateObj.last_changed}" .hass="${this._hass}"></ha-relative-time>
-                </div>` : null;
+            const secondaryInfo = this._config.secondary_info;
+            let content = undefined;
+
+            if (secondaryInfo === 'last-changed') {
+                content = html`<ha-relative-time .datetime="${this.stateObj.last_changed}" .hass="${this._hass}"></ha-relative-time>`;
+            } else if (secondaryInfo === 'last-updated') {
+                content = html`<ha-relative-time .datetime="${this.stateObj.last_updated}" .hass="${this._hass}"></ha-relative-time>`;
+            } else if (secondaryInfo in this.stateObj.attributes) {
+                content = this.stateObj.attributes[secondaryInfo];
+            }
+
+            return content ? html`<div class="secondary">${content}</div>` : null;
         }
 
         renderWarning() {


### PR DESCRIPTION
I improved `secondary_info` to support custom attributes and `last-updated`.

My battery entities all have a custom `battery_type` attribute to help me remember what goes where. With the secondary info customization I no longer need to access it in the more-info popup.

Also fixes #9, which was caused by https://github.com/home-assistant/frontend/pull/7709